### PR TITLE
Examples and API Upgrades

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,11 @@
+# Example Files for copilot-ops
+
+This directory contains a collection of example files which can be used in tandem
+with the copilot-ops tool.
+Feel free to play around with these files and see how `copilot-ops` responds.
+
+Some examples you could run:
+
+```sh
+go run main.go patch -f robinhood.yaml --request "@robinhood.yaml needs an additional field to hold 50000 units of AMC stock"
+```

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,8 +4,16 @@ This directory contains a collection of example files which can be used in tande
 with the copilot-ops tool.
 Feel free to play around with these files and see how `copilot-ops` responds.
 
-Some examples you could run:
+### stock-data.yaml 
+
 
 ```sh
-go run main.go patch -f robinhood.yaml --request "@robinhood.yaml needs an additional field to hold 50000 units of AMC stock"
+# to change values within .data
+go run main.go patch -f stock-data.yaml --request "@stock-data.yaml needs an additional field to hold 50000 units of AMC stock"
+
+# to rename the configmap
+go run main.go patch -f stock-data.yaml --request "rename the configmap to 'stock-holdings'"
+
+# to erase existing fields
+go run main.go patch -f examples/stock-data.yaml --request "remove the existing data fields in @stock-data.yaml"
 ```

--- a/examples/robinhood.yaml
+++ b/examples/robinhood.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: myapp-robinhood
+data:
+  # amount of stock
+  GME: "2400"
+  # measured in thousand
+  USD: "25000"

--- a/examples/stock-data.yaml
+++ b/examples/stock-data.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: myapp-robinhood
+  name: myapp-stock-data
 data:
   # amount of stock
   GME: "2400"

--- a/pkg/cmd/patch.go
+++ b/pkg/cmd/patch.go
@@ -129,21 +129,28 @@ func RunPatch(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	fmOut := filemap.NewFilemap()
-	err = fmOut.DecodeFromOutput(output)
+	err = fm.DecodeFromOutput(output)
 	if err != nil {
 		return err
 	}
 
-	fmOut.LogDump()
+	fm.LogDump()
 
 	if write {
 		log.Printf("updating files ...\n")
-		err = fmOut.WriteUpdatesToFiles()
+		err = fm.WriteUpdatesToFiles()
 		if err != nil {
 			return err
 		}
 	} else {
+		// TODO: Add output formatting control
+		// just encode the output and print it to stdout
+		// TODO: print as redirectable / pipeable write stream
+		fmOutput, err := fm.EncodeToInputTextFullPaths()
+		if err != nil {
+			return err
+		}
+		log.Printf("\n%s\n", fmOutput)
 		log.Printf("use --write to actually update files\n")
 	}
 

--- a/pkg/cmd/patch.go
+++ b/pkg/cmd/patch.go
@@ -118,12 +118,13 @@ func RunPatch(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	ai, err := openai.CreateOpenAIClient()
-	if err != nil {
-		return err
-	}
-
-	output, err := ai.EditCode(input, request)
+	// create OpenAI client
+	// TODO: get these values from a config, potentially global
+	openAIClient := openai.CreateOpenAIClient(
+		os.Getenv("OPENAI_API_KEY"),
+		os.Getenv("OPENAI_ORG_ID"),
+	)
+	output, err := openAIClient.EditCode(input, request)
 	if err != nil {
 		return err
 	}

--- a/pkg/filemap/filemap.go
+++ b/pkg/filemap/filemap.go
@@ -107,7 +107,7 @@ func (fm *Filemap) EncodeToInputText() (string, error) {
 	var i int = 0
 	// join the files together along with their tag
 	for tagname, file := range fm.Files {
-		input += fmt.Sprintf("# %s\n%s\n", tagname, file.Content)
+		input += fmt.Sprintf("# @%s\n%s\n", tagname, file.Content)
 		// insert a '---' between each file, but not after the last file
 		if 1 < len(fm.Files) && i < len(fm.Files)-1 {
 			input += "---\n"

--- a/pkg/filemap/filemap.go
+++ b/pkg/filemap/filemap.go
@@ -12,9 +12,12 @@ import (
 
 // File represents a file which was referenced in the issue to be updated.
 type File struct {
-	Path    string `json:"path"`
+	// Path is the path to the file.
+	Path string `json:"path"`
+	// Content is the content of the file.
 	Content string `json:"content"`
-	Tag     string `json:"tag"`
+	// Tag is the tagname of the file.
+	Tag string `json:"tag"`
 }
 
 // Filemap represents a mapping of files in a directory by their tagnames.
@@ -108,6 +111,22 @@ func (fm *Filemap) EncodeToInputText() (string, error) {
 	// join the files together along with their tag
 	for tagname, file := range fm.Files {
 		input += fmt.Sprintf("# @%s\n%s\n", tagname, file.Content)
+		// insert a '---' between each file, but not after the last file
+		if 1 < len(fm.Files) && i < len(fm.Files)-1 {
+			input += "---\n"
+		}
+		i++
+	}
+	return input, nil
+}
+
+// EncodeToInputTextFullPaths Encodes the filemap into a string using each file's full path as its tagname.
+func (fm *Filemap) EncodeToInputTextFullPaths() (string, error) {
+	var input string = ""
+	var i int = 0
+	// join the files together along with their tag
+	for _, file := range fm.Files {
+		input += fmt.Sprintf("# @%s\n%s\n", file.Path, file.Content)
 		// insert a '---' between each file, but not after the last file
 		if 1 < len(fm.Files) && i < len(fm.Files)-1 {
 			input += "---\n"

--- a/pkg/openai/edit.go
+++ b/pkg/openai/edit.go
@@ -6,10 +6,10 @@ import (
 )
 
 const (
-	EditEndpoint       string = "edits"
-	CompletionEndpoint string = "completions"
-	OpenAIEndpointV1   string = "https://api.openai.com/v1"
-	OpenAICodeDavinci2 string = "code-davinci-002"
+	EditEndpoint            string = "edits"
+	CompletionEndpoint      string = "completions"
+	OpenAIEndpointV1        string = "https://api.openai.com/v1"
+	OpenAICodeDavinciEditV1 string = "code-davinci-edit-001"
 )
 
 // GetFirstChoice Returns the string contents of the first choice returned by the AI engine.

--- a/pkg/openai/openai.go
+++ b/pkg/openai/openai.go
@@ -31,11 +31,12 @@ func (openAI OpenAIClient) EnginePath() string {
 
 // APIHeaders Returns a map of headers to be used when making requests to the OpenAI API.
 func (openAI *OpenAIClient) APIHeaders() map[string]string {
-	headers := make(map[string]string)
-	headers["Content-Type"] = "application/json"
-	headers["Accept"] = "application/json"
-	headers["Authorization"] = "Bearer " + openAI.AuthToken
-	headers["User-Agent"] = "copilot-ops-cli"
+	headers := map[string]string{
+		"Content-Type":  "application/json",
+		"Accept":        "application/json",
+		"User-Agent":    "copilot-ops-cli",
+		"Authorization": fmt.Sprintf("Bearer %s", openAI.AuthToken),
+	}
 
 	// set the Org ID if provided
 	if openAI.OrganizationID != "" {

--- a/pkg/openai/types.go
+++ b/pkg/openai/types.go
@@ -30,4 +30,18 @@ type OpenAIClient struct {
 	// Engine represents the engine used when getting completions from OpenAI.
 	// TODO: Create a constant enumeration of engines so that we can include their character limits.
 	Engine string
+	// AuthToken is the token used to authenticate with the OpenAI API.
+	AuthToken string
+	// OrganizationID is the ID of the organization used to authenticate with the OpenAI API.
+	OrganizationID string
+}
+
+// ErrorResponse Defines an Error object which will be returned by OpenAI when an error occurs.
+type ErrorResponse struct {
+	Error *struct {
+		Code    *int    `json:"code,omitempty"`
+		Message string  `json:"message"`
+		Type    *string `json:"type,omitempty"`
+		Param   string  `json:"param"`
+	} `json:"error,omitempty"`
 }


### PR DESCRIPTION
This pull-request introduces the following changes:
- Users can load the Organization ID from ENV via `OPENAI_ORG_ID`. 
- A new `ErrorResponse` type is added to handle error responses from OpenAI's API.
- A `examples` directory is introduced, with files to demonstrate API usage on
- Implements writing to stdout
 
The following bug-fixes are made:
- OpenAI engine is changed to `code-davinci-edit-001` 
- Tags are inserted as `# @[basepath]` 