### PR TITLE
Touch-up Example Credentials & README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,16 +41,17 @@ Here's a breakdown of the generate process:
 
 ```sh
 # to create a Jupyter Notebook which uses a GPU to accelerate machine-learning tasks
-copilot-ops generate --write \
-	--request "create a Jupyter Notebook that specifies a GPU resource"
+copilot-ops generate --request "create a Jupyter Notebook that specifies a GPU resource"
 
 # to generate a Pod that mounts a given ConfigMap
-copilot-ops generate -f examples/stock-data.yaml --write \
-  --request "create a Pod which runs an express.js app and mounts the stock-data configmap to trade stocks"
+copilot-ops generate -f examples/stock-data.yaml --request '
+	create a Pod which runs an express.js app and mounts the stock-data configmap to trade stocks
+'
 
 # launch a Job which pulls data from the S3 bucket at 's3://my-bucket/data.csv' and loads it into a PVC in the same namespace
-copilot-ops generate -f examples/aws-credentials-secret.yaml --write \
-	--request "create a Job which pulls data from the S3 bucket at 's3://my-bucket/data.csv' and loads it into a PVC in the same namespace"
+copilot-ops generate -f examples/aws-credentials-secret.yaml --request '
+	create a Job which pulls data from the S3 bucket at "s3://my-bucket/data.csv" and loads it into a PVC in the same namespace
+'
 
 ```
 

--- a/examples/aws-credentials-secret.yaml
+++ b/examples/aws-credentials-secret.yaml
@@ -4,7 +4,7 @@ metadata:
     name: aws-access-keys
 type: Opaque
 data:
-    aws_access_key_id: ba3b9f8f-c9b7-4b5b-b8b7-f8f9f8f8f8f8
-    aws_secret_access_key: 87ab23c5ef5190a
+    aws_access_key_id: deadbeef12345678
+    aws_secret_access_key: hunter2
     aws_default_region: us-east-1
     aws_account: "123456789012"


### PR DESCRIPTION
This PR touches up some of the credentials in examples & removes the `--write` flag from example commands.
Signed-off-by: Oleg <97077423+RobotSail@users.noreply.github.com>