### PR TITLE
add todo-to-issue github workflow

### DIFF
--- a/.github/workflows/todo-issue.yaml
+++ b/.github/workflows/todo-issue.yaml
@@ -1,0 +1,13 @@
+name: "TODO to issue"
+on: 
+  push:
+    branches:
+      - "main"
+jobs:
+  golang-to-list:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@master"
+      - name: "TODO to Issue"
+        uses: "alstr/todo-to-issue-action@v4.6.5"
+        id: "todo"


### PR DESCRIPTION
This PR adds a GitHub issue to the CI workflow which inspects each commit made to the `main` branch for `TODO`-type comments, e.g HACK, FIXME, DOCUMENT, etc. and turns them into issues. 
That way, we can keep better track of improvements that must be made to the codebase as it evolves. 
 
Signed-off-by: Oleg <97077423+RobotSail@users.noreply.github.com>