### PR TITLE
modify prompt so that @tagname is included in responses more frequently

### DIFF
--- a/pkg/cmd/edit.go
+++ b/pkg/cmd/edit.go
@@ -1,8 +1,10 @@
 package cmd
 
 import (
+	"fmt"
 	"log"
 
+	"github.com/redhat-et/copilot-ops/pkg/filemap"
 	"github.com/redhat-et/copilot-ops/pkg/openai"
 	"github.com/spf13/cobra"
 )
@@ -41,7 +43,11 @@ func RunEdit(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	output, err := r.OpenAI.EditCode(r.FilemapText, r.UserRequest)
+	// trigger GPT-3 to preserve the @tagname format in the file
+	editSuffix := fmt.Sprintf("The resulting file should preserve the '# %stagname' format used to identify the YAML(s).", filemap.FILE_TAG_PREFIX)
+	editInstruction := fmt.Sprintf("%s\n\n%s", r.UserRequest, editSuffix)
+
+	output, err := r.OpenAI.EditCode(r.FilemapText, editInstruction)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR includes a message to the edit instruction stating that the tagname should be preserved in-between edits.
GPT-3 seems to respond better with this suffix from first-hand accounts, however this was only with $n < 10$ trials. 
Signed-off-by: Oleg <97077423+RobotSail@users.noreply.github.com>