### PR TITLE
Readme clt update

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Requirements
 
 In order to use `copilot-ops`, you need to have an OpenAI account with access to the GPT-3 Codex model,
-and an API token saved as the `OPENAI_API_TOKEN` environment variable.
+and an API token saved as the `OPENAI_API_TOKEN` environment variable. You must also have golang installed to build the binary.
 
 ## Installation
 
@@ -17,6 +17,27 @@ git clone https://github.com/redhat-et/copilot-ops.git
 
 # Build the binary
 make build
+
+# Create bin directory
+mkdir -p ${HOME}/bin
+
+# Save binary to bin directory (run from copilot-ops directory)
+cp copilot-ops ${HOME}/bin
+
+# Make binary executable 
+chmod 755 ${HOME}/bin/copilot-ops
+
+# Open file ${HOME}/.bashrc in text editor, add line and save
+export PATH= "${HOME}/bin:${PATH}"
+
+# Rerun .bashrc file 
+. ~/.bashrc
+
+# Ensure binary is on PATH
+command -v copilot-ops
+
+# Run binary with -h to see all commands
+copilot-ops -h
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,10 @@ git clone https://github.com/redhat-et/copilot-ops.git
 
 # Build the binary
 make build
+```
+To install the command line tool, complete the following steps:
 
+```console
 # Create bin directory
 mkdir -p ${HOME}/bin
 


### PR DESCRIPTION
This PR updates the README to include instructions for installing copilot-ops as a command line tool. 