### PR TITLE
Reworks the OpenAI client to pass the AI model in the model parameter

### DIFF
--- a/pkg/cmd/utils.go
+++ b/pkg/cmd/utils.go
@@ -97,14 +97,9 @@ func PrepareRequest(cmd *cobra.Command, engine string) (*Request, error) {
 	openAIClient := openai.CreateOpenAIClient(conf.OpenAI.ApiKey, conf.OpenAI.OrgId, engine)
 	openAIClient.NTokens = nTokens
 	openAIClient.NCompletions = nCompletions
+	openAIClient.Engine = engine
 
-	if cmd.Name() == COMMAND_EDIT {
-		openAIClient.Engine = openai.OpenAICodeDavinciEditV1
-	} else {
-		openAIClient.Engine = openai.OpenAICodeDavinciV2
-	}
-
-	println(openAIClient.Engine)
+	log.Printf("Model in use: " + openAIClient.Engine)
 
 	r := Request{
 		Config:      conf,

--- a/pkg/cmd/utils.go
+++ b/pkg/cmd/utils.go
@@ -98,6 +98,14 @@ func PrepareRequest(cmd *cobra.Command, engine string) (*Request, error) {
 	openAIClient.NTokens = nTokens
 	openAIClient.NCompletions = nCompletions
 
+	if cmd.Name() == COMMAND_EDIT {
+		openAIClient.Engine = openai.OpenAICodeDavinciEditV1
+	} else {
+		openAIClient.Engine = openai.OpenAICodeDavinciV2
+	}
+
+	println(openAIClient.Engine)
+
 	r := Request{
 		Config:      conf,
 		Filemap:     fm,

--- a/pkg/openai/openai.go
+++ b/pkg/openai/openai.go
@@ -98,7 +98,9 @@ func (openAI *OpenAIClient) EditCode(input string, instruction string) (string, 
 	var editBody EditRequestBody = EditRequestBody{
 		Instruction: instruction,
 		Input:       input,
-		Model:       openAI.Engine,
+		BodyParameters: BodyParameters{
+			Model: openAI.Engine,
+		},
 	}
 
 	// make the request
@@ -133,9 +135,9 @@ func (openAI *OpenAIClient) GenerateCode(input string) ([]string, error) {
 		Stop:      []string{CompletionEndOfSequence},
 		MaxTokens: openAI.NTokens,
 		N:         openAI.NCompletions,
-		Model:     openAI.Engine,
 		BodyParameters: BodyParameters{
 			Temperature: 0,
+			Model:       openAI.Engine,
 		},
 	}
 

--- a/pkg/openai/openai.go
+++ b/pkg/openai/openai.go
@@ -59,7 +59,7 @@ func (openAI *OpenAIClient) MakeRequest(endpoint string, body interface{}) ([]by
 	bodyBytes := io.Reader(bytes.NewReader(jsonBody))
 
 	// build the request
-	apiURL := openAI.APIUrl + "/" + openAI.EnginePath() + "/" + endpoint
+	apiURL := openAI.APIUrl + "/" + endpoint
 	req, err := http.NewRequest("POST", apiURL, bodyBytes)
 	if err != nil {
 		return nil, err
@@ -98,6 +98,7 @@ func (openAI *OpenAIClient) EditCode(input string, instruction string) (string, 
 	var editBody EditRequestBody = EditRequestBody{
 		Instruction: instruction,
 		Input:       input,
+		Model:       openAI.Engine,
 	}
 
 	// make the request
@@ -132,6 +133,7 @@ func (openAI *OpenAIClient) GenerateCode(input string) ([]string, error) {
 		Stop:      []string{CompletionEndOfSequence},
 		MaxTokens: openAI.NTokens,
 		N:         openAI.NCompletions,
+		Model:     openAI.Engine,
 		BodyParameters: BodyParameters{
 			Temperature: 0,
 		},

--- a/pkg/openai/types.go
+++ b/pkg/openai/types.go
@@ -18,6 +18,7 @@ type OpenAIResponse struct {
 }
 
 type BodyParameters struct {
+	Model string `json:"model"`
 	// Temperature Is the sampling temperature to use. Higher values means the model will take more risks. Try 0.9 for more creative applications, and 0 (argmax sampling) for ones with a well-defined answer.
 	Temperature float32 `json:"temperature,omitempty"`
 	TopP        int     `json:"top_p,omitempty"`

--- a/pkg/openai/types.go
+++ b/pkg/openai/types.go
@@ -18,6 +18,7 @@ type OpenAIResponse struct {
 }
 
 type BodyParameters struct {
+	// Model is the model used by OpenAI to generate completions
 	Model string `json:"model"`
 	// Temperature Is the sampling temperature to use. Higher values means the model will take more risks. Try 0.9 for more creative applications, and 0 (argmax sampling) for ones with a well-defined answer.
 	Temperature float32 `json:"temperature,omitempty"`
@@ -27,7 +28,6 @@ type BodyParameters struct {
 // EditRequestBody Defines the parameters for the /edit endpoint.
 type EditRequestBody struct {
 	BodyParameters
-	Model       string `json:"model"`
 	Instruction string `json:"instruction"`
 	Input       string `json:"input,omitempty"`
 }
@@ -35,8 +35,6 @@ type EditRequestBody struct {
 // CompletionRequestBody Defines the body of data for requests that must be sent to the Completions endpoint.
 type CompletionRequestBody struct {
 	BodyParameters
-	// Model is the model used by OpenAI to generate completions
-	Model string `json:"model"`
 	// Prompt is the prompt to generate completions for, it can be encoded as a string, or as an array of strings.
 	Prompt string `json:"prompt"`
 	// Suffix is the suffix that comes after a completion of inserted text.

--- a/pkg/openai/types.go
+++ b/pkg/openai/types.go
@@ -26,6 +26,7 @@ type BodyParameters struct {
 // EditRequestBody Defines the parameters for the /edit endpoint.
 type EditRequestBody struct {
 	BodyParameters
+	Model       string `json:"model"`
 	Instruction string `json:"instruction"`
 	Input       string `json:"input,omitempty"`
 }
@@ -33,6 +34,8 @@ type EditRequestBody struct {
 // CompletionRequestBody Defines the body of data for requests that must be sent to the Completions endpoint.
 type CompletionRequestBody struct {
 	BodyParameters
+	// Model is the model used by OpenAI to generate completions
+	Model string `json:"model"`
 	// Prompt is the prompt to generate completions for, it can be encoded as a string, or as an array of strings.
 	Prompt string `json:"prompt"`
 	// Suffix is the suffix that comes after a completion of inserted text.


### PR DESCRIPTION
This PR reworks the OpenAI client to pass the AI model in the 'model' parameter of a request, rather than in the URL.

Signed-off-by: djach7 <djachimo@redhat.com>