### PR TITLE
use os.Stdout.WriteString instead of fmt.Printf

### DIFF
--- a/pkg/cmd/utils.go
+++ b/pkg/cmd/utils.go
@@ -135,8 +135,10 @@ func PrintOrWriteOut(r *Request) error {
 	if err != nil {
 		return err
 	}
-	// stringOut := strings.ReplaceAll(fmOutput, "\\n", "\n")
-	fmt.Printf("%s\n", fmOutput)
+	_, err = os.Stdout.WriteString(fmOutput)
+	if err != nil {
+		return fmt.Errorf("could not write to stdout: %w", err)
+	}
 
 	return nil
 }


### PR DESCRIPTION
This PR removes usage of `fmt.Printf` so that the linter passes & image builds.
Signed-off-by: Oleg <97077423+RobotSail@users.noreply.github.com>